### PR TITLE
Make methods less internal

### DIFF
--- a/src/dom.rs
+++ b/src/dom.rs
@@ -456,14 +456,13 @@ impl<A> DomBuilder<A> {
 
     #[inline]
     pub fn apply<F>(self, f: F) -> Self where F: FnOnce(Self) -> Self {
-        self.apply_if(true, f)
+        f(self)
     }
 
     #[inline]
     pub fn apply_if<F>(self, test: bool, f: F) -> Self where F: FnOnce(Self) -> Self {
         if test {
             f(self)
-
         } else {
             self
         }
@@ -1068,6 +1067,11 @@ impl StylesheetBuilder {
         self
     }
 
+    #[inline]
+    pub fn apply<F>(self, f: F) -> Self where F: FnOnce(Self) -> Self {
+        f(self)
+    }
+
     // TODO return a Handle
     #[inline]
     pub fn finish(mut self) {
@@ -1137,6 +1141,11 @@ impl ClassBuilder {
 
         self.stylesheet = self.stylesheet.style_important_signal(name, value);
         self
+    }
+
+    #[inline]
+    pub fn apply<F>(self, f: F) -> Self where F: FnOnce(Self) -> Self {
+        f(self)
     }
 
     // TODO return a Handle ?

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -345,10 +345,9 @@ fn set_style<A, B>(style: &CssStyleDeclaration, name: &A, value: B, important: b
 }
 
 // TODO should this inline ?
-fn set_style_signal<A, B, C, D>(style: CssStyleDeclaration, callbacks: &mut Callbacks, name: A, value: D, important: bool)
+fn set_style_signal<A, C, D>(style: CssStyleDeclaration, callbacks: &mut Callbacks, name: A, value: D, important: bool)
     where A: MultiStr + 'static,
-          B: MultiStr,
-          C: OptionStr<Output = B>,
+          C: OptionStr,
           D: Signal<Item = C> + 'static {
 
     set_option(style, callbacks, value, move |style, value| {
@@ -911,10 +910,9 @@ impl<A> DomBuilder<A> where A: AsRef<HtmlElement> {
 
 impl<A> DomBuilder<A> where A: AsRef<HtmlElement> {
     #[inline]
-    pub fn style_signal<B, C, D, E>(mut self, name: B, value: E) -> Self
+    pub fn style_signal<B, D, E>(mut self, name: B, value: E) -> Self
         where B: MultiStr + 'static,
-              C: MultiStr,
-              D: OptionStr<Output = C>,
+              D: OptionStr,
               E: Signal<Item = D> + 'static {
 
         set_style_signal(self.element.as_ref().style(), &mut self.callbacks, name, value, false);
@@ -922,10 +920,9 @@ impl<A> DomBuilder<A> where A: AsRef<HtmlElement> {
     }
 
     #[inline]
-    pub fn style_important_signal<B, C, D, E>(mut self, name: B, value: E) -> Self
+    pub fn style_important_signal<B, D, E>(mut self, name: B, value: E) -> Self
         where B: MultiStr + 'static,
-              C: MultiStr,
-              D: OptionStr<Output = C>,
+              D: OptionStr,
               E: Signal<Item = D> + 'static {
 
         set_style_signal(self.element.as_ref().style(), &mut self.callbacks, name, value, true);
@@ -1052,10 +1049,9 @@ impl StylesheetBuilder {
     }
 
     #[inline]
-    pub fn style_signal<B, C, D, E>(mut self, name: B, value: E) -> Self
+    pub fn style_signal<B, D, E>(mut self, name: B, value: E) -> Self
         where B: MultiStr + 'static,
-              C: MultiStr,
-              D: OptionStr<Output = C>,
+              D: OptionStr,
               E: Signal<Item = D> + 'static {
 
         set_style_signal(self.element.clone(), &mut self.callbacks, name, value, false);
@@ -1063,10 +1059,9 @@ impl StylesheetBuilder {
     }
 
     #[inline]
-    pub fn style_important_signal<B, C, D, E>(mut self, name: B, value: E) -> Self
+    pub fn style_important_signal<B, D, E>(mut self, name: B, value: E) -> Self
         where B: MultiStr + 'static,
-              C: MultiStr,
-              D: OptionStr<Output = C>,
+              D: OptionStr,
               E: Signal<Item = D> + 'static {
 
         set_style_signal(self.element.clone(), &mut self.callbacks, name, value, true);
@@ -1125,10 +1120,9 @@ impl ClassBuilder {
     }
 
     #[inline]
-    pub fn style_signal<B, C, D, E>(mut self, name: B, value: E) -> Self
+    pub fn style_signal<B, D, E>(mut self, name: B, value: E) -> Self
         where B: MultiStr + 'static,
-              C: MultiStr,
-              D: OptionStr<Output = C>,
+              D: OptionStr,
               E: Signal<Item = D> + 'static {
 
         self.stylesheet = self.stylesheet.style_signal(name, value);
@@ -1136,10 +1130,9 @@ impl ClassBuilder {
     }
 
     #[inline]
-    pub fn style_important_signal<B, C, D, E>(mut self, name: B, value: E) -> Self
+    pub fn style_important_signal<B, D, E>(mut self, name: B, value: E) -> Self
         where B: MultiStr + 'static,
-              C: MultiStr,
-              D: OptionStr<Output = C>,
+              D: OptionStr,
               E: Signal<Item = D> + 'static {
 
         self.stylesheet = self.stylesheet.style_important_signal(name, value);

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1092,6 +1092,15 @@ impl StylesheetBuilder {
         self.callbacks.leak();
         self.selector
     }
+
+    #[inline]
+    pub fn finish_class(self) -> String {
+        let mut selector = self.finish();
+        if selector.remove(0) != '.' {
+            panic!("Selector is not a class");
+        }
+        selector
+    }
 }
 
 

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1149,7 +1149,8 @@ impl StylesheetBuilder {
     #[inline]
     pub fn style_unchecked_signal<B, C, D, E>(mut self, name: B, value: E) -> Self
         where B: AsStr + 'static,
-              D: OptionStr,
+              C: AsStr,
+              D: OptionStr<Output = C>,
               E: Signal<Item = D> + 'static {
 
         set_style_unchecked_signal(self.element.clone(), &mut self.callbacks, name, value, false);

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -503,14 +503,12 @@ impl<A> DomBuilder<A> where A: Clone {
         self.element.clone()
     }
 
-    #[deprecated(since = "0.5.1", note = "Use the with_node macro instead")]
     #[inline]
     pub fn with_element<B, F>(self, f: F) -> B where F: FnOnce(Self, A) -> B {
         let element = self.element.clone();
         f(self, element)
     }
 
-    #[deprecated(since = "0.5.20", note = "Use the with_node macro instead")]
     #[inline]
     pub fn before_inserted<F>(self, f: F) -> Self where F: FnOnce(A) {
         let element = self.element.clone();

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1120,14 +1120,14 @@ pub mod __internal {
 
 
     pub struct Pseudo<'a, A> {
-        class_name: &'a str,
+        selector: &'a str,
         pseudos: A,
     }
 
     impl<'a, A> Pseudo<'a, A> where A: MultiStr {
         #[inline]
-        pub fn new(class_name: &'a str, pseudos: A) -> Self {
-            Self { class_name, pseudos }
+        pub fn new(selector: &'a str, pseudos: A) -> Self {
+            Self { selector, pseudos }
         }
     }
 
@@ -1135,7 +1135,7 @@ pub mod __internal {
         #[inline]
         fn find_map<B, F>(&self, mut f: F) -> Option<B> where F: FnMut(&str) -> Option<B> {
             self.pseudos.find_map(|x| {
-                f(&format!(".{}{}", self.class_name, x))
+                f(&format!(":is({}){}", self.selector, x))
             })
         }
     }

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -1115,7 +1115,7 @@ pub mod __internal {
         let id = CLASS_ID.fetch_add(1, Ordering::Relaxed);
 
         // TODO make this more efficient ?
-        format!("__class_{}__", id)
+        format!(".__class_{}__", id)
     }
 
 

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -473,8 +473,7 @@ impl<A> DomBuilder<A> {
 
 impl<A> DomBuilder<A> where A: Clone {
     #[inline]
-    #[doc(hidden)]
-    pub fn __internal_element(&self) -> A {
+    pub fn element(&self) -> A {
         self.element.clone()
     }
 
@@ -516,6 +515,10 @@ impl<A> DomBuilder<A> where A: Into<Node> {
             element: self.element.into(),
             callbacks: self.callbacks,
         }
+    }
+    #[inline]
+    pub fn finish(self) -> Dom {
+        self.into_dom()
     }
 }
 
@@ -991,9 +994,8 @@ pub struct StylesheetBuilder {
 // TODO remove the CssStyleRule when this is discarded
 impl StylesheetBuilder {
     // TODO should this inline ?
-    #[doc(hidden)]
     #[inline]
-    pub fn __internal_new<A>(selector: A) -> Self where A: MultiStr {
+    pub fn new<A>(selector: A) -> Self where A: MultiStr {
         // TODO can this be made faster ?
         // TODO somehow share this safely between threads ?
         thread_local! {
@@ -1073,8 +1075,7 @@ impl StylesheetBuilder {
 
     // TODO return a Handle
     #[inline]
-    #[doc(hidden)]
-    pub fn __internal_done(mut self) {
+    pub fn finish(mut self) {
         self.callbacks.trigger_after_insert();
 
         // This prevents it from triggering after_remove
@@ -1091,21 +1092,19 @@ pub struct ClassBuilder {
 }
 
 impl ClassBuilder {
-    #[doc(hidden)]
     #[inline]
-    pub fn __internal_new() -> Self {
+    pub fn new() -> Self {
         let class_name = __internal::make_class_id();
 
         Self {
             // TODO make this more efficient ?
-            stylesheet: StylesheetBuilder::__internal_new(&format!(".{}", class_name)),
+            stylesheet: StylesheetBuilder::new(&format!(".{}", class_name)),
             class_name,
         }
     }
 
-    #[doc(hidden)]
     #[inline]
-    pub fn __internal_class_name(&self) -> &str {
+    pub fn class_name(&self) -> &str {
         &self.class_name
     }
 
@@ -1148,10 +1147,9 @@ impl ClassBuilder {
     }
 
     // TODO return a Handle ?
-    #[doc(hidden)]
     #[inline]
-    pub fn __internal_done(self) -> String {
-        self.stylesheet.__internal_done();
+    pub fn finish(self) -> String {
+        self.stylesheet.finish();
         self.class_name
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,170 @@
 #![warn(unreachable_pub)]
 #![deny(warnings)]
-
 #![cfg_attr(feature = "nightly", allow(incomplete_features))]
 #![cfg_attr(feature = "nightly", feature(const_generics))]
 
+//! Zero-cost ultra-high-performance declarative DOM library using FRP signals for Rust! \
+
+//! # Getting Started
+//! Can be used as a standalone DOM rendering library but comes into its own when paired with
+//! [futures-signals](https://docs.rs/futures-signals/). The best place to start is the
+//! [Signals tutorial](https://docs.rs/futures-signals/*/futures_signals/tutorial/index.html)
+//! and then become acquainted with [`DomBuilder<A>`](crate::dom::DomBuilder) and [`html!`](crate::html!).
+//! Idiomatic use is:
+//! - Create `struct` components that own data
+//! - Wrap any data that can change in a [`Mutable<T>`](https://docs.rs/futures-signals/*/futures_signals/signal/struct.Mutable.html),
+//! [`MutableVec<T>`](https://docs.rs/futures-signals/*/futures_signals/signal_vec/struct.MutableVec.html), or
+//! [`MutableBTreeMap<K, V>`](https://docs.rs/futures-signals/*/futures_signals/signal_map/struct.MutableBTreeMap.html)
+//! - Create render functions for each `struct` component
+//! - Avoid local state in the DOM: all flags, triggers, data etc. for rendering should be stored in the `struct`
+//! - Call the render functions for each component in a chain all the way down
+//!
+//! `dominator` handles any necessary DOM updates on changes to the data. A basic app looks something like the
+//! below, but refer to the [examples](https://github.com/Pauan/rust-dominator/tree/master/examples) for a
+//! comprehensive set of best practices.
+//! ```
+//! use dominator::{events::Click, html, Dom};
+//! use futures_signals::signal::Mutable;
+//! use wasm_bindgen::prelude::*;
+//!
+//! // Top level App component
+//! struct App {
+//!     name: String,
+//!     info: Info, // Info sub-component
+//! }
+//!
+//! impl App {
+//!     fn new(msg: &str) -> Self {
+//!         Self {
+//!             name: String::from("Dominator App"),
+//!             info: Info::new(msg),
+//!         }
+//!     }
+//!     fn render(app: Self) -> Dom {
+//!         html!("div", {
+//!             .text(&app.name)
+//!             // Call sub-component rendering functions
+//!             .child(Info::render(&app.info))
+//!         })
+//!     }
+//! }
+//!
+//! // Info sub-component
+//! struct Info {
+//!     msg: Mutable<String>, // String value that can change over time
+//! }
+//!
+//! impl Info {
+//!     fn new(msg: &str) -> Self {
+//!         Self {
+//!             msg: Mutable::new(String::from(msg)),
+//!         }
+//!     }
+//!     fn render(info: &Self) -> Dom {
+//!         html!("button", {
+//!             // Text will automatically update on any changes to `msg`
+//!             .text_signal(info.msg.signal_cloned())
+//!             .event({
+//!                 // Clone due to move + 'static
+//!                 let msg = info.msg.clone();
+//!                 // Update `msg` when clicked
+//!                 move |_: Click| msg.set(String::from("Clicked"))
+//!             })
+//!         })
+//!     }
+//! }
+//!
+//! #[wasm_bindgen(start)]
+//! pub fn main_js() -> Result<(), JsValue> {
+//!     let app = App::new("Hello world");
+//!     dominator::append_dom(&dominator::body(), App::render(app));
+//!     Ok(())
+//! }
+//! ```
+
+//! ## Handling `'static` web apis
+//! There are lots of `'static` lifetime requirements for web apis and therefore calls to `move` and `clone`: so
+//! [`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) and [`Rc<T>`](https://doc.rust-lang.org/std/rc/struct.Rc.html)
+//! quickly come in handy. Which to use? As a general rule [`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html)
+//! for rust types unless they [`!Send`](https://doc.rust-lang.org/nomicon/send-and-sync.html):
+//! currently on WASM rust uses [single threaded primitives](https://github.com/rust-lang/rust/blob/1f94abcda6884893d4723304102089198caa0839/library/std/src/sys/wasm/mod.rs)
+//! so there is no cost to using atomics and you will be ready for multi-threaded wasm;
+//! use [`Rc<T>`](https://doc.rust-lang.org/std/rc/struct.Rc.html) for any JS values which are not thread safe and likely never will be.
+//! \
+//! \
+//! There is the [`clone!`](crate::clone!) macro which is a nice shorthand for the many calls to `.clone()`.
+//! \
+//! \
+//! [`MutableVec<T>`](https://docs.rs/futures-signals/*/futures_signals/signal_vec/struct.MutableVec.html) and
+//! [`MutableBTreeMap<K, V>`](https://docs.rs/futures-signals/*/futures_signals/signal_map/struct.MutableBTreeMap.html) do
+//! not `impl Clone` so if you want to make them cloneable you will need to wrap them in an [`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html)
+//! or [`Rc<T>`](https://doc.rust-lang.org/std/rc/struct.Rc.html).
+
+//! ## Clone and [`Mutable<T>`](https://docs.rs/futures-signals/*/futures_signals/signal/struct.Mutable.html)
+//! [`Mutable<T>`](https://docs.rs/futures-signals/*/futures_signals/signal/struct.Mutable.html)
+//! uses [`Arc<T>`](https://doc.rust-lang.org/std/sync/struct.Arc.html) internally so cloning it
+//! calls [`Arc::clone`](https://doc.rust-lang.org/std/sync/struct.Arc.html#impl-Clone) and
+//! will create another pointer to the same allocation. This can have subtle consequences when cloning any
+//! structs with [`Mutable<T>`](https://docs.rs/futures-signals/*/futures_signals/signal/struct.Mutable.html) in.
+//! ```
+//! #[derive(Clone)]
+//! struct Info {
+//!     msg: Mutable<String>,
+//! }
+//!
+//! let item = Info {
+//!     msg: Mutable::new(String::from("original")),
+//! };
+//!
+//! let item_clone = item.clone();
+//!
+//! // All updates to `msg` on the clone will update it on the original
+//! item_clone.msg.set(String::from("both changed"));
+//!
+//! assert_eq!(item.msg.get_cloned(), item_clone.msg.get_cloned());
+//!
+//! // All updates to `msg` on the original will update it on the clone
+//! item.msg.set(String::from("changed again"));
+//!
+//! assert_eq!(item.msg.get_cloned(), item_clone.msg.get_cloned());
+//! ```
+
+//! # Mixins
+//! `dominator` has a great way of creating reusable functionalities and components: create a function with
+//! the signature `DomBuilder<A> -> DomBuilder<A>`.
+//! ```
+//! fn mixin<A>(builder: DomBuilder<A>) -> DomBuilder<A> {
+//!     // Do some stuff with the builder and then return it
+//!     builder
+//! }
+//! ```
+//! It can then be called from within the [`html!`](crate::html!) macro using the [`apply`](crate::dom::DomBuilder::apply) or
+//! [`apply_if`](crate::dom::DomBuilder::apply_if) methods:
+//! ```
+//! html!("div", {
+//!     .apply(mixin)
+//!     .apply_if(true, mixin)
+//! })
+//! ```
+
+//! ## js Bundler
+//! `dominator` works really well when paired with the [rollup.js](https://www.rollupjs.org/guide/en/) and the
+//! [rust rollup plugin](https://github.com/wasm-tool/rollup-plugin-rust). See the
+//! [examples](https://github.com/Pauan/rust-dominator/tree/master/examples) folders for how to get setup.
 
 #[macro_use]
 mod macros;
-mod utils;
+
 mod bindings;
 mod callbacks;
-mod operations;
 mod dom;
+mod operations;
+mod utils;
 
-pub use web_sys::ShadowRootMode;
 pub use dom::*;
-pub mod traits;
+pub use web_sys::ShadowRootMode;
+
 pub mod animation;
-pub mod routing;
 pub mod events;
+pub mod routing;
+pub mod traits;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -314,7 +314,7 @@ macro_rules! stylesheet {
 }
 
 /// Creates a unique auto-generated CSS classname and injects it into [`document.styleSheets`](https://developer.mozilla.org/en-US/docs/Web/API/Document/styleSheets).
-/// It wraps [`ClassBuilder`](crate::ClassBuilder) and takes any of its methods.
+/// It wraps [`StylesheetBuilder`](crate::StylesheetBuilder) and takes any of its methods.
 /// ```
 /// let padding = Mutable::new(10);
 ///
@@ -349,7 +349,7 @@ macro_rules! stylesheet {
 #[macro_export]
 macro_rules! class {
     ($($methods:tt)*) => {{
-        $crate::ClassBuilder::finish($crate::apply_methods!($crate::ClassBuilder::new(), { $($methods)* }))
+        $crate::StylesheetBuilder::finish($crate::apply_methods!($crate::StylesheetBuilder::new_unique_class(), { $($methods)* }))
     }};
 }
 
@@ -372,7 +372,7 @@ macro_rules! pseudo {
         $crate::pseudo!($this, $rules, {})
     };
     ($this:ident, $rules:expr, { $($methods:tt)* }) => {{
-        $crate::stylesheet!($crate::__internal::Pseudo::new($crate::ClassBuilder::class_name(&$this), $rules), { $($methods)* });
+        $crate::stylesheet!($crate::__internal::Pseudo::new($crate::StylesheetBuilder::selector(&$this), $rules), { $($methods)* });
         $this
     }};
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,36 @@
+/// Allows the application of methods to a type using the standard `dominator` macro syntax. Used internally by
+/// most of the other macros [`html!`](crate::html!), [`with_node!`](crate::with_node!), [`with_cfg!`](crate::with_cfg!),
+/// [`shadow_root!`](crate::shadow_root!), [`dom_builder!`](crate::dom_builder!), [`stylesheet!`](crate::stylesheet!),
+/// [`class!`](crate::class!). It puts each method call in a separate statement: this is to ensure that a
+/// [lock](https://doc.rust-lang.org/std/sync/struct.RwLock.html) created inside one method call will not extend
+/// to the rest of the method calls.
+/// Since [`Mutable<T>`](https://docs.rs/futures-signals/*/futures_signals/signal/struct.Mutable.html),
+/// [`MutableVec<T>`](https://docs.rs/futures-signals/*/futures_signals/signal_vec/struct.MutableVec.html), or
+/// [`MutableBTreeMap<K, V>`](https://docs.rs/futures-signals/*/futures_signals/signal_map/struct.MutableBTreeMap.html) all use
+/// [RwLock](https://doc.rust-lang.org/std/sync/struct.RwLock.html) internally this is important for subsequent method calls
+/// that may want to access the same data.
+/// It also accepts some of the other macros [`with_node!`](crate::with_node!), [`with_cfg!`](crate::with_cfg!),
+/// [`shadow_root!`](crate::shadow_root!), [`pseudo!`](crate::pseudo) and will elide the first `this:expr` parameter
+/// in the macro calls.
+///
+/// ```
+/// let body = web_sys::window()
+///     .unwrap()
+///     .document()
+///     .unwrap()
+///     .body()
+///     .unwrap();
+///
+/// let builder = DomBuilder::new(body);
+///
+/// apply_methods!(builder, {
+///     .with_node!(node => {
+///         .event(move |_: events::Click| node.set_inner_text("Goodbye"))
+///         .text("Hello world")
+///     })
+///     .class("my-class")
+/// });
+/// ```
 #[macro_export]
 macro_rules! apply_methods {
     ($this:expr, {}) => {
@@ -13,7 +46,6 @@ macro_rules! apply_methods {
         $crate::apply_methods!(this, { $($rest)* })
     }};
 }
-
 
 #[doc(hidden)]
 #[macro_export]
@@ -34,7 +66,34 @@ macro_rules! __internal_builder {
     }};
 }
 
-
+/// Provides owned access to the internal element of a [`dom_builder!`](crate::dom_builder!) and is used for
+/// passing the element into other builder methods. Runs before the element is inserted into the DOM.
+/// Typically used within [`html!`](crate::html!) where the first builder term is elided.
+/// ```
+/// html!("div", {
+///     .with_node!(div => {
+///         // allows access to the underlying 'div' HtmlElement
+///         .event(move |_: events::Click| div.set_inner_text("Goodbye"))
+///     })
+///     .text("Hello world")
+/// });
+/// ```
+/// It can also be used directly with [dom_builder!](crate::dom_builder!):
+/// ```
+/// let body = web_sys::window()
+///     .unwrap()
+///     .document()
+///     .unwrap()
+///     .body()
+///     .unwrap();
+///
+/// let builder = DomBuilder::new(body);
+///
+/// with_node!(builder, body => {
+///     .event(move |_: events::Click| body.set_inner_text("Goodbye"))
+///     .text("Hello world")
+/// });
+/// ```
 #[macro_export]
 macro_rules! with_node {
     ($this:ident, $name:ident => { $($methods:tt)* }) => {{
@@ -43,7 +102,32 @@ macro_rules! with_node {
     }};
 }
 
-
+/// Used to apply methods to a builder based upon a standard rust `#[cfg(predicate)]`.
+/// Typically used within one of the other builder macros where the first builder term is elided.
+/// If used with the [rollup-plugin-rust](https://github.com/wasm-tool/rollup-plugin-rust#build-options) the
+/// required `cargo build` arguments are added using `cargoArgs: ["--features", "foo"]`.
+/// ```
+/// html!("div", {
+///     .with_cfg!(feature = "foo", {
+///         .text("Using the foo feature")
+///     })
+/// });
+/// ```
+/// It can also be used directly with any of the builders.
+/// ```
+/// let body = web_sys::window()
+///     .unwrap()
+///     .document()
+///     .unwrap()
+///     .body()
+///     .unwrap();
+///
+/// let builder = DomBuilder::new(body);
+///
+/// with_cfg!(builder, feature = "foo", {
+///     .text("Using the foo feature")
+/// });
+/// ```
 #[macro_export]
 macro_rules! with_cfg {
     ($this:ident, $cfg:meta, { $($methods:tt)* }) => {{
@@ -57,7 +141,37 @@ macro_rules! with_cfg {
     }};
 }
 
-
+/// Attaches DOM elements to the [ShadowRoot](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot) of
+/// a DOM element. The internal element type of the macro is [`ShadowRoot`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.ShadowRoot.html)
+/// and it requires [`ShadowRootMode`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/enum.ShadowRootMode.html) as a parameter.
+/// ```
+/// shadow_root!(dom_builder, shadow_root_mode => { .dom_builder_methods })
+/// ```
+/// Typically used within the [`html!`](crate::html!) macro where the [`DomBuilder<A>`](crate::DomBuilder) is elided:
+/// ```
+/// html!("div", {
+///     .shadow_root!(web_sys::ShadowRootMode::Open => {
+///         .text("Shadow dom")
+///     })
+/// });
+/// ```
+/// It can also be used directly with [`DomBuilder<A>`](crate::DomBuilder):
+/// ```
+/// let body = web_sys::window()
+///     .unwrap()
+///     .document()
+///     .unwrap()
+///     .body()
+///     .unwrap();
+///
+/// let builder = DomBuilder::new(body);
+///
+/// shadow_root!(builder, web_sys::ShadowRootMode::Open => {
+///     .child(html!("div", {
+///         .text("Shadow dom")
+///     }))
+/// });
+/// ```
 #[macro_export]
 macro_rules! shadow_root {
     ($this:ident, $mode:expr => { $($methods:tt)* }) => {{
@@ -67,7 +181,54 @@ macro_rules! shadow_root {
     }};
 }
 
-
+/// Used to build a [`Dom`](crate::dom::Dom) and is a wrapper over [`DomBuilder<A>`](crate::dom::DomBuilder).
+/// By default the macro is internally typed to [`HtmlElement`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.HtmlElement.html).
+/// Note if you want to generate [SVG](http://www.w3.org/2000/svg) make sure to use the [svg!](crate::svg!) macro.
+/// ```
+/// html!("html_tag", { .dom_builder_methods })
+/// ```
+/// ```
+/// // <div></div>
+/// html!("div");
+///
+/// // <my-tag></my-tag>
+/// html!("my-tag");
+///
+/// // <div>Hello world</div>
+/// html!("div", {
+///     .text("Hello world")
+/// });
+///
+/// // <div class="my-class">Hello world</div>
+/// html!("div", {
+///      .text("Hello world")
+///      .class("my-class")
+///  });
+/// ```
+/// It can be typed to any [element](https://rustwasm.github.io/wasm-bindgen/api/web_sys/index.html) that
+/// `impl` [JsCast](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/trait.JsCast.html#).
+/// ```
+/// html!("html_tag" => internal_element_type , { .dom_builder_methods })
+/// ```
+/// e.g. [HtmlInputElement](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.HtmlInputElement.html)
+/// ```
+/// // <input placeholder="type here">
+/// html!("input" => HtmlInputElement, {
+///     .attr("placeholder", "type here")
+/// });
+/// ```
+/// Why would you want to know the type? Well once you start using some of the [DomBuilder](crate::dom::DomBuilder) methods
+/// knowing the html element type allows you to call its associated methods:
+/// ```
+/// html!("input" => HtmlInputElement, {
+///     .before_inserted(|input| {
+///         // .value() is a method on HtmlInputElement, but not on HtmlElement
+///         if input.value().is_empty() {
+///             input.set_value("Hello")
+///         }
+///     })
+/// });
+/// ```
 #[macro_export]
 macro_rules! html {
     ($($args:tt)+) => {
@@ -75,7 +236,21 @@ macro_rules! html {
     };
 }
 
-
+/// Used to create SVG elements. Exactly like the [`html!`](crate::html!) macro in that it wraps [`DomBuilder<A>`](crate::dom::DomBuilder)
+/// but it creates elements correctly namespaced to [SVG](http://www.w3.org/2000/svg). The default internal element
+/// type is [`SvgElement`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.SvgElement.html)
+///
+/// ```
+/// // <svg>
+/// //   <rect width="100px" height="100px"></rect>
+/// // </svg>
+/// svg!("svg", {
+///     .child(svg!("rect" => SvgRectElement, {
+///         .attr("width", "100px")
+///         .attr("height", "100px")
+///     }))
+/// });
+/// ```
 #[macro_export]
 macro_rules! svg {
     ($($args:tt)+) => {
@@ -83,7 +258,24 @@ macro_rules! svg {
     };
 }
 
+/// Used to wrap an existing DOM node in a [`DomBuilder<A>`](crate::dom::DomBuilder)
+/// where the node being wrapped must [`impl AsRef<web_sys::Element>`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Element.html).
+/// ```
+/// dom_builder!(node_to_wrap, { .dom_builder_methods })
+/// ```
 
+/// ```
+/// let body = web_sys::window()
+///     .unwrap()
+///     .document()
+///     .unwrap()
+///     .body()
+///     .unwrap();
+///
+/// dom_builder!(body, {
+///     .before_inserted(|body| body.set_inner_text("Hello world"))
+/// });
+/// ```
 #[macro_export]
 macro_rules! dom_builder {
     ($node:expr, { $($methods:tt)* }) => {{
@@ -93,7 +285,24 @@ macro_rules! dom_builder {
     }};
 }
 
-
+/// Creates a global CSS stylesheet: similar to creating a `.css` file. It wraps [`StylesheetBuilder`](crate::StylesheetBuilder),
+/// the first argument is the element selector(s) that needs to `impl` [`MultiStr`](crate::traits::MultiStr) and then
+/// any of the [`StylesheetBuilder`](crate::StylesheetBuilder) methods.
+/// ```
+/// stylesheet("tag_selector(s)", { .stylesheet_builder_methods })
+/// ```
+/// It is not often used since [class!](crate::class!) is superior but its useful for changing the html and body elements:
+/// ```
+/// stylesheet!("html, body", {
+///     .style("margin", "0px")
+/// })
+/// ```
+/// Or applying styles to everything:
+/// ```
+/// stylesheet!("*", {
+///     .style("box-sizing", "border-box")
+/// })
+/// ```
 #[macro_export]
 macro_rules! stylesheet {
     ($rule:expr) => {
@@ -104,7 +313,39 @@ macro_rules! stylesheet {
     };
 }
 
-
+/// Creates a unique auto-generated CSS classname and injects it into [`document.styleSheets`](https://developer.mozilla.org/en-US/docs/Web/API/Document/styleSheets).
+/// It wraps [`ClassBuilder`](crate::ClassBuilder) and takes any of its methods.
+/// ```
+/// let padding = Mutable::new(10);
+///
+/// let class = class! {
+///     .style("display", "block")
+///     .style_signal("padding", padding.signal_cloned().map(|v| format!("{}px", v)))
+/// };
+///
+/// html!("button", {
+///     .class(class)
+///     .event(move |_: events::Click| {
+///         let mut s = padding.lock_mut();
+///         *s += 10;
+///     })
+///     .text("Push")
+/// });
+/// ```
+/// It is often declared as `static` (when not using `.style_signal`) so it is only made once:
+/// ```
+/// use once_cell::sync::Lazy;
+///
+/// static BUTTON_CLASS: Lazy<String> = Lazy::new(|| {
+///     class! {
+///         .style("padding", "20px")
+///     }
+/// });
+///
+/// html!("button", {
+///     .class(&*BUTTON_CLASS)
+/// });
+/// ```
 #[macro_export]
 macro_rules! class {
     ($($methods:tt)*) => {{
@@ -112,7 +353,16 @@ macro_rules! class {
     }};
 }
 
-
+/// Used to generate [pseudo classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes). Typically
+/// called from within the [`class!`](crate::class!) macro:
+/// ```
+/// class!(
+///     .style("background-color", "black")
+///     .pseudo!(":nth-child(1)", {
+///         .style("background-color", "blue")
+///     })
+/// );
+/// ```
 #[macro_export]
 macro_rules! pseudo {
     ($this:ident, $rules:expr) => {
@@ -124,24 +374,57 @@ macro_rules! pseudo {
     }};
 }
 
-
 // TODO this is pretty inefficient, it iterates over the token tree one token at a time
 // TODO this should only work for ::std::clone::Clone::clone
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __internal_clone_split {
-    (($($x:ident)*), $t:ident => $y:expr) => {{
-        $(let $x = $x.clone();)*
-        let $t = $t.clone();
-        $y
-    }};
-    (($($x:ident)*), $t:ident, $($after:tt)*) => {
-        $crate::__internal_clone_split!(($($x)* $t), $($after)*)
-    };
-}
-
 // TODO move into gloo ?
+
+/// Used as a shorthand syntax for calling `.clone()` when parsing variables into functions. Due to
+/// `'static` requirements of many of the web apis `move` and `clone` are frequently required.
+/// ```
+/// clone!(clone_item_1, clone_item_2, clone_item_3 => { expression using the clones })
+/// ```
+/// Where the `clone_item_x` shadow existing variable names.
+/// So instead of writing:
+/// ```
+/// let text = Mutable::new("text");
+/// let other_text = Mutable::new("other text");
+/// html!("div", {
+///     .event({
+///         let text = text.clone();
+///         let other_text = text.clone();
+///         move |_: events::Click| {
+///         text.set("clicked");
+///         other_text.set("clicked")
+///     }})
+///     .event({
+///         let other_text = other_text.clone();
+///         move |_: events::Focus| {
+///         text.set("focused");
+///         other_text.set("focused")
+///     }})
+///     .text_signal(other_text.signal_cloned())
+/// });
+/// ```
+/// `clone!` can make a cleaner syntax sharing the same variable names:
+/// ```
+/// let text = Mutable::new("text");
+/// let other_text = Mutable::new("other text");
+/// html!("div", {
+///     .event(clone!(text, other_text => move |_: events::Click| {
+///         text.set("clicked");
+///         other_text.set("clicked")
+///     }))
+///     .event(clone!(other_text => move |_: events::Focus| {
+///         text.set("focused");
+///         other_text.set("focused")
+///     }))
+///     .text_signal(other_text.signal_cloned())
+/// });
+/// ```
 #[macro_export]
 macro_rules! clone {
-    ($($input:tt)*) => { $crate::__internal_clone_split!((), $($input)*) };
+    ($($x:ident),* => $y:expr) => {{
+        $(let $x = $x.clone();)*
+        $y
+    }};
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -423,8 +423,8 @@ macro_rules! pseudo {
 /// ```
 #[macro_export]
 macro_rules! clone {
-    ($($x:ident),* => $y:expr) => {{
-        $(let $x = $x.clone();)*
+    ($($x:ident),+ => $y:expr) => {{
+        $(let $x = $x.clone();)+
         $y
     }};
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -38,7 +38,7 @@ macro_rules! __internal_builder {
 #[macro_export]
 macro_rules! with_node {
     ($this:ident, $name:ident => { $($methods:tt)* }) => {{
-        let $name = $crate::DomBuilder::__internal_element(&$this);
+        let $name = $crate::DomBuilder::element(&$this);
         $crate::apply_methods!($this, { $($methods)* })
     }};
 }
@@ -100,7 +100,7 @@ macro_rules! stylesheet {
         $crate::stylesheet!($rule, {})
     };
     ($rule:expr, { $($methods:tt)* }) => {
-        $crate::StylesheetBuilder::__internal_done($crate::apply_methods!($crate::StylesheetBuilder::__internal_new($rule), { $($methods)* }))
+        $crate::StylesheetBuilder::finish($crate::apply_methods!($crate::StylesheetBuilder::new($rule), { $($methods)* }))
     };
 }
 
@@ -108,7 +108,7 @@ macro_rules! stylesheet {
 #[macro_export]
 macro_rules! class {
     ($($methods:tt)*) => {{
-        $crate::ClassBuilder::__internal_done($crate::apply_methods!($crate::ClassBuilder::__internal_new(), { $($methods)* }))
+        $crate::ClassBuilder::finish($crate::apply_methods!($crate::ClassBuilder::new(), { $($methods)* }))
     }};
 }
 
@@ -119,7 +119,7 @@ macro_rules! pseudo {
         $crate::pseudo!($this, $rules, {})
     };
     ($this:ident, $rules:expr, { $($methods:tt)* }) => {{
-        $crate::stylesheet!($crate::__internal::Pseudo::new($crate::ClassBuilder::__internal_class_name(&$this), $rules), { $($methods)* });
+        $crate::stylesheet!($crate::__internal::Pseudo::new($crate::ClassBuilder::class_name(&$this), $rules), { $($methods)* });
         $this
     }};
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -353,13 +353,16 @@ macro_rules! class {
     }};
 }
 
-/// Used to generate [pseudo classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes). Typically
-/// called from within the [`class!`](crate::class!) macro:
+/// Used to generate [pseudo classes and elements](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements).
+/// Usually called from within the [`class!`](crate::class!) macro:
 /// ```
 /// class!(
 ///     .style("background-color", "black")
 ///     .pseudo!(":nth-child(1)", {
 ///         .style("background-color", "blue")
+///     })
+///     .pseudo!("::after", {
+///         .style("background-color", "red")
 ///     })
 /// );
 /// ```

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -154,7 +154,7 @@ array_multi_strs!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
 
 
 pub trait OptionStr {
-    type Output;
+    type Output: MultiStr;
 
     fn into_option(self) -> Option<Self::Output>;
 }


### PR DESCRIPTION
This pull request makes quite a lot of __internal_ things on DomBuilder, StylesheetBuilder, ClassBuilder visible from outside.

Why do I want this?

Currently, the only way to use these methods are from utility macros, despite them being perfectly fine usable by themselves.
For example, instead of just doing ClassBuilder::new().style("foo", "bar").finish(), I am forced to call the macro.
Similarly, the with_node! macro only works within a html! context, and not a DomBuilder::new_html("foo")....into_dom()
Without the methods being public, its hard to make custom macros, as I have to directly inspect the source code.
As the macros to access the methods are currently undocumented, it is difficult to see which macro should be used. For example, from looking at the ClassBuilder documentation it is unclear how to generate one; this could also be solved by documenting the macros, but that might better be served by exposing the methods and saying "You can also use with_node!".
This pull request also adds a finish() method to DomBuilder, in order to make its api more similar to StylesheetBuilder and ClassBuilder, which both are given finish() methods.